### PR TITLE
Fix socket handlers when user request/deny/accept meetings

### DIFF
--- a/client/public/socket.client.js
+++ b/client/public/socket.client.js
@@ -1,6 +1,5 @@
 var socket = io.connect('http://localhost:8000');
 var activeUsers = {};
-var userId = socket.id;
 var userProfile = null;
 //Sender profile will be set only if the user receives a meeting request
 var senderProfile = null;
@@ -9,6 +8,8 @@ var senderId = null;
 /********** Socket-Client Controllers **********/
 
 var renderTimerComponent = function (userId) {
+  console.log('Wow you are popular, people want to hang out');
+
   //Render timer component on acceptance
   //var profile = activeUsers[userId];
 };
@@ -28,7 +29,7 @@ var rejectMeetingRequest = function() {
 };
 
 var sendMeetingRequest = function(receiverId) {
-  socket.emit('request meeting', userId, receiverId);
+  socket.emit('request meeting', socket.id, receiverId);
 };
 
 var updateUserLocation = function(userProfile) {
@@ -45,6 +46,7 @@ var updateUserLocation = function(userProfile) {
 /******** Socket-Client Event Handlers *********/
 
 var inboundRequestHandler = function(userId) {
+  console.log('Look! Inbound request is here');
   senderProfile = activeUsers[userId];
   senderId = userId;
 };

--- a/client/public/socket.client.js
+++ b/client/public/socket.client.js
@@ -1,18 +1,52 @@
 var socket = io.connect('http://localhost:8000');
 var activeUsers = {};
-var user = null;
+var userId = socket.id;
+var userProfile = null;
+//Sender profile will be set only if the user receives a meeting request
+var senderProfile = null;
+var senderId = null;
 
+/********** Socket-Client Controllers **********/
 
-/****** Socket-Client Event Handlers *******/
+var renderTimerComponent = function (userId) {
+  //Render timer component on acceptance
+  //var profile = activeUsers[userId];
+};
 
-var updateUserLocation = function(user) {
+var renderRejectionComponent = function (userId) {
+  //Render rejection component
+  //var profile = activeUsers[userId];
+};
+
+var acceptMeetingRequest = function() {
+  socket.emit('lets do it', senderId);
+  renderTimerComponent(senderId);
+};
+
+var rejectMeetingRequest = function() {
+  socket.emit('no thanks', senderId);
+};
+
+var sendMeetingRequest = function(receiverId) {
+  socket.emit('request meeting', userId, receiverId);
+};
+
+var updateUserLocation = function(userProfile) {
   if (navigator.geolocation) {
     navigator.geolocation.getCurrentPosition(function(position) {
-      user.lat = position.coords.latitude;
-      user.lng = position.coords.longitude;
-      socket.emit('update new user coords', user, socket.id);
+      userProfile.lat = position.coords.latitude;
+      userProfile.lng = position.coords.longitude;
+      socket.emit('update new user coords', userProfile, socket.id);
     });
   }
+};
+
+
+/******** Socket-Client Event Handlers *********/
+
+var inboundRequestHandler = function(userId) {
+  senderProfile = activeUsers[userId];
+  senderId = userId;
 };
 
 var notifyNewUserConnection = function() {
@@ -21,9 +55,9 @@ var notifyNewUserConnection = function() {
 };
 
 var saveNewUser = function(data) {
-  if (!user) {
-    user = data;
-    updateUserLocation(user);
+  if (!userProfile) {
+    userProfile = data;
+    updateUserLocation(userProfile);
   }
 };
 
@@ -31,16 +65,13 @@ var updateAllUserData = function(data) {
   activeUsers = data;
 };
 
-var inboundRequestHandler = function(userId) {
 
-};
-
-/****** Socket-Client Event Listeners ******/
+/******** Socket-Client Event Listeners ********/
 
 socket.on('connect', notifyNewUserConnection);
 socket.on('save new user', saveNewUser);
 socket.on('update all users', updateAllUserData);
-
 socket.on('lets meet', inboundRequestHandler);
 
-
+socket.on('user said no', renderRejectionComponent);
+socket.on('user said yes', renderTimerComponent);

--- a/server/config/socket.server.js
+++ b/server/config/socket.server.js
@@ -18,18 +18,18 @@ var io = function(io) {
     /******** Socket-Server Event Handlers *********/
 
     var sendRejection = function(senderId) {
-      socket.to(senderId).emit('user said no', socketId);
+      socket.broadcast.to('/#' + senderId).emit('user said no', socketId);
       receiverId = null;
     };
 
     var sendConfirmation = function(senderId) {
-      socket.to(senderId).emit('user said yes', socketId);
+      socket.broadcast.to('/#' + senderId).emit('user said yes', socketId);
       receiverId = null;
     };
 
     var outboundRequestHandler = function(senderId, receiveId) {
       receiverId = receiveId;
-      socket.to(receiverId).emit('lets meet', senderId);
+      socket.broadcast.to('/#' + receiverId).emit('lets meet', senderId);
     };
 
     var refreshAllUserData = function(userData, id) {


### PR DESCRIPTION
#### What does this PR do?

Allows user to request deny accept meetings in real time
#### Where should the reviewer start?

socket.server.js and socket.client.js files
#### How should this be manually tested?
1. Open up two browsers with two different facebook logins and then open the console for both browsers.
2. Get the browser's current socket id by calling socket.id, copy and paste that, go into the other browser, and call sendMeetingRequest and pass in that socket.id into the function. The other browser should automatically log "Look! inbound request" to indicate that private socket broadcasting is working.
#### Any background context you want to provide?

This ultimately will lead to rendering of some components depending on what decision the user ends up making.
#### What are the relevant tickets on Pivotal Tracker?

N/A
#### Provide screenshots (if appropriate).

N/A
