### PR TITLE
Remove google maps API key from source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 client/public/peer.js
 client/public/temp.peer.js
+client/public/apiKeys.js
 # Ignore bundled webpack modules #
 client/public/webpack.min.js
 client/public/webpack.min.js.map

--- a/README.md
+++ b/README.md
@@ -55,17 +55,13 @@ Install [Node](https://nodejs.org/en/) and [MongoDB](https://www.mongodb.com/dow
 
 You'll also need to set up Facebook, Google Maps, and Peer JS API keys in order to develop for Unplanned:
 
-[Google Maps API Key](https://developers.google.com/maps/documentation/android-api/signup#get_an_api_key_from_the_console_name) - Set the key inside of script tag src in index.html like so:
-
-![Index Html Example](https://cloud.githubusercontent.com/assets/15970451/15833878/81930ce8-2bdd-11e6-888d-ec9300ae9ed1.png)
-
 [Facebook Login Key/APP ID](https://developers.facebook.com/) - Create a new Facebook App and retrieve the App ID. The Facebook callback URL should be set as http://localhost:8000/auth/facebook/callback, and then the APP ID should be set inside webpackEntry.js
 
 ![Facebook Callback URL](https://cloud.githubusercontent.com/assets/15970451/15833832/528e0722-2bdd-11e6-846b-4cd0638b2fd2.png)
 
-[PeerJS Key](http://peerjs.com/) - For access to Video Calling. You will need to store this in a new file called peer.min.js inside of the public folder. Check the index.html file for reference
+[Google Maps API Key](https://developers.google.com/maps/documentation/android-api/signup#get_an_api_key_from_the_console_name) - You will need to store your Google Maps API key in apiKeys.js inside of the public folder. apiKey.example.js is provided as a template.
 
-![Peer Key Example](https://cloud.githubusercontent.com/assets/15970451/15833879/8194f526-2bdd-11e6-8aed-561373f3ea77.png)
+[PeerJS Key](http://peerjs.com/) - For access to Video Calling. You will need to store your peer api key in apiKeys.js inside of the public folder. apiKey.example.js is provided as a template.
 
 Everything else will be included inside NPM install.
 

--- a/client/public/apiKeys.example.js
+++ b/client/public/apiKeys.example.js
@@ -1,0 +1,4 @@
+// Fill out your API Keys below for each service.
+// Rename this file to apiKeys.js
+window.peerKey = 'hfskdhfkahsfkhsdkf';
+window.googleApiKey = 'ajksdfhkahfdkhsdkfjhkshf';

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -8,8 +8,11 @@
   <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/grids-responsive-min.css">
   <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/base-min.css">
   <script src="http://cdn.peerjs.com/0.3/peer.min.js"></script>
-  <script src="peer.js"></script>
-  <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAtGXLK72mst-2nTDk2iR9Kwjzt6aL47jo"></script>
+  <script src="apiKeys.js"></script>
+  <script type="text/javascript">
+    var apiSrc = 'https://maps.googleapis.com/maps/api/js?key=' + window.googleApiKey;
+    document.write('<script type="text/javascript" src="' + apiSrc + '"></scr' + 'ipt>');
+  </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0-rc1/jquery.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
#### What does this PR do?

Removes the google maps api key from the source.
Also centralize the two front-end api keys for peer and google into one file name apiKeys.js.
#### Where should the reviewer start?

apiKeys.example.js is the template that you'd have to setup for yourself with your API keys.
#### How should this be manually tested?

Add in the api keys into apiKeys.js and test the map and video.
#### Any background context you want to provide?

This change is necessary as it is not good practice to have api key in github.
I will be making the google maps api key we have been using void since it's already in previous git commits. We can use a new key - added to slack. 
#### What are the relevant tickets on Pivotal Tracker?
#### Provide screenshots (if appropriate).
